### PR TITLE
Add valtio-reactive framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "solid-js": "^1.9.3",
     "svelte": "5.2.7",
     "usignal": "^0.9.0",
-    "valtio": "^2.1.2"
+    "valtio": "^2.1.2",
+    "valtio-reactive": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       valtio:
         specifier: ^2.1.2
         version: 2.1.2(react@18.3.1)
+      valtio-reactive:
+        specifier: ^0.1.0
+        version: 0.1.0(valtio@2.1.2(react@18.3.1))
     devDependencies:
       '@types/node':
         specifier: ^22.9.1
@@ -1115,6 +1118,11 @@ packages:
     resolution: {integrity: sha512-CVNliz6KF2yet3HBIkbFJKZmjlt95C8dsNZDnwoS6X98+QJRpsSz9uxo3TziBqdyJQkWwfD3VG9lRzsQNvF24Q==}
     engines: {node: '>= 0.6.0'}
 
+  valtio-reactive@0.1.0:
+    resolution: {integrity: sha512-Tct50NWi/wV5/Glg5Dd+0AySjSib4JEhZ33ysduHuLImjOq8Xu8FW/Aj4ISyzEMMzzDFkUUVvD/EpHBqUtFKLg==}
+    peerDependencies:
+      valtio: '>=2.0.0'
+
   valtio@2.1.2:
     resolution: {integrity: sha512-fhekN5Rq7dvHULHHBlJeXHrQDl0Jj9GXfNavCm3gkD06crGchaG1nf/J7gSlfZU2wPcRdVS5jBKWHtE2NNz97A==}
     engines: {node: '>=12.20.0'}
@@ -1990,6 +1998,10 @@ snapshots:
   usignal@0.9.0: {}
 
   v8-natives@1.2.5: {}
+
+  valtio-reactive@0.1.0(valtio@2.1.2(react@18.3.1)):
+    dependencies:
+      valtio: 2.1.2(react@18.3.1)
 
   valtio@2.1.2(react@18.3.1):
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,9 +16,12 @@ import { vueReactivityFramework } from "./frameworks/vueReactivity";
 import { xReactivityFramework } from "./frameworks/xReactivity";
 import { svelteFramework } from "./frameworks/svelte";
 // import { compostateFramework } from "./frameworks/compostate";
-// import { valtioFramework } from "./frameworks/valtio";
+import { valtioFramework } from "./frameworks/valtio";
 
 export const frameworkInfo: FrameworkInfo[] = [
+  // NOTE: Valtio currently hangs on some of the `dynamic` tests, so disable it if you want to run them. (https://github.com/pmndrs/valtio/discussions/949)
+  { framework: valtioFramework },
+
   { framework: alienFramework, testPullCounts: true },
   { framework: preactSignalFramework, testPullCounts: true },
   { framework: svelteFramework, testPullCounts: true },
@@ -41,8 +44,6 @@ export const frameworkInfo: FrameworkInfo[] = [
   // { framework: compostateFramework },
   // NOTE: the kairo adapter is currently broken and unused.
   // { framework: kairoFramework, testPullCounts: true },
-  // NOTE: Valtio currently hangs on some of the `dynamic` tests, so disable it if you want to run them. (https://github.com/pmndrs/valtio/discussions/949)
-  // { framework: valtioFramework },
 ];
 
 export const perfTests: TestConfig[] = [


### PR DESCRIPTION
See https://github.com/pmndrs/valtio/discussions/949 and https://github.com/valtiojs/valtio-reactive

@dai-shi I was excited to add `valtio-reactive` to the suite to compare apples-to-apples, but the unit tests for my `valtio-reactive` wrapper are currently failing. I think it's because the core signal's read isn't being tracked?