### PR TITLE
Isolate libraries in different processes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "printWidth": 140,
   "singleQuote": false,
   "jsxSingleQuote": false,
   "semi": true,

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "vitest run",
-    "build": "esbuild src/index.ts --bundle --format=cjs --platform=node --outdir=dist --sourcemap=external",
+    "build": "esbuild src/index.ts --bundle --splitting --format=esm --platform=node --outdir=dist --sourcemap=external",
     "run": "node --expose-gc dist/index.js",
-    "bench": "esbuild src/index.ts --bundle --format=cjs --platform=node | node --expose-gc"
+    "bench": "pnpm run build && pnpm run run"
   },
   "keywords": [],
   "author": "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,48 +1,30 @@
 import { TestConfig, FrameworkInfo } from "./util/frameworkTypes";
 
-import { alienFramework } from "./frameworks/alienSignals";
-import { angularFramework } from "./frameworks/angularSignals";
-import { mobxFramework } from "./frameworks/mobx";
-import { tc39SignalsProposalStage0 } from "./frameworks/tc39-proposal-signals-stage-0";
-import { molWireFramework } from "./frameworks/molWire";
-import { obyFramework } from "./frameworks/oby";
-import { preactSignalFramework } from "./frameworks/preactSignals";
-import { reactivelyFramework } from "./frameworks/reactively";
-import { signiaFramework } from "./frameworks/signia";
-import { solidFramework } from "./frameworks/solid";
-import { sFramework } from "./frameworks/s";
-import { usignalFramework } from "./frameworks/uSignal";
-import { vueReactivityFramework } from "./frameworks/vueReactivity";
-import { svelteFramework } from "./frameworks/svelte";
-import { tansuFramework } from "./frameworks/tansu";
-// import { compostateFramework } from "./frameworks/compostate";
-// import { valtioFramework } from "./frameworks/valtio";
-
-export const frameworkInfo: FrameworkInfo[] = [
-  { framework: alienFramework, testPullCounts: true },
-  { framework: preactSignalFramework, testPullCounts: true },
-  { framework: svelteFramework, testPullCounts: true },
-  { framework: tc39SignalsProposalStage0, testPullCounts: true },
-  { framework: reactivelyFramework, testPullCounts: true },
-  { framework: sFramework },
-  { framework: tansuFramework, testPullCounts: true },
-  { framework: angularFramework, testPullCounts: true },
-  { framework: molWireFramework, testPullCounts: true },
-  { framework: obyFramework, testPullCounts: true },
-  { framework: signiaFramework, testPullCounts: true },
-  { framework: solidFramework },
-  { framework: usignalFramework, testPullCounts: true },
-  { framework: vueReactivityFramework, testPullCounts: true },
+export const frameworkInfo: (() => Promise<FrameworkInfo>)[] = [
+  async () => ({ framework: (await import("./frameworks/alienSignals")).alienFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/preactSignals")).preactSignalFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/svelte")).svelteFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/tc39-proposal-signals-stage-0")).tc39SignalsProposalStage0, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/reactively")).reactivelyFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/s")).sFramework }),
+  async () => ({ framework: (await import("./frameworks/tansu")).tansuFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/angularSignals")).angularFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/molWire")).molWireFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/oby")).obyFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/signia")).signiaFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/solid")).solidFramework }),
+  async () => ({ framework: (await import("./frameworks/uSignal")).usignalFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/vueReactivity")).vueReactivityFramework, testPullCounts: true }),
   // NOTE: MobX currently hangs on some of the `dynamic` tests and `cellx` tests, so disable it if you want to run them. (https://github.com/mobxjs/mobx/issues/3926)
-  { framework: mobxFramework, testPullCounts: false },
+  async () => ({ framework: (await import("./frameworks/mobx")).mobxFramework, testPullCounts: false }),
 
   // --- Disabled frameworks ---
   // NOTE: the compostate adapter is currently broken and unused.
-  // { framework: compostateFramework },
+  // async () => ({ framework: (await import("./frameworks/compostate")).compostateFramework }),
   // NOTE: the kairo adapter is currently broken and unused.
-  // { framework: kairoFramework, testPullCounts: true },
+  // async () => ({ framework: (await import("./frameworks/kairo")).kairoFramework, testPullCounts: true }),
   // NOTE: Valtio currently hangs on some of the `dynamic` tests, so disable it if you want to run them. (https://github.com/pmndrs/valtio/discussions/949)
-  // { framework: valtioFramework },
+  // async () => ({ framework: (await import("./frameworks/valtio")).valtioFramework }),
 ];
 
 export const perfTests: TestConfig[] = [

--- a/src/frameworks.test.ts
+++ b/src/frameworks.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from "vitest";
 import { FrameworkInfo, TestConfig } from "./util/frameworkTypes";
 import { frameworkInfo } from "./config";
 
-frameworkInfo.forEach((frameworkInfo) => frameworkTests(frameworkInfo));
+(await Promise.all(frameworkInfo.map((frameworkLoader) => frameworkLoader()))).forEach((frameworkInfo) => frameworkTests(frameworkInfo));
 
 function makeConfig(): TestConfig {
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import cluster from "cluster";
 import { dynamicBench } from "./dynamicBench";
 // import { cellxbench } from "./cellxBench";
 import { sbench } from "./sBench";
@@ -5,12 +6,12 @@ import { frameworkInfo } from "./config";
 import { logPerfResult, perfReportHeaders } from "./util/perfLogging";
 import { molBench } from "./molBench";
 import { kairoBench } from "./kairoBench";
+import { FrameworkInfo } from "./util/frameworkTypes";
 
-async function main() {
-  logPerfResult(perfReportHeaders());
-  (globalThis as any).__DEV__ = true;
+async function testFramework(frameworkTestPromise: () => Promise<FrameworkInfo>) {
+  try {
+    (globalThis as any).__DEV__ = true;
 
-  for (const frameworkTestPromise of frameworkInfo) {
     const frameworkTest = await frameworkTestPromise();
     const { framework } = frameworkTest;
     await kairoBench(framework);
@@ -24,8 +25,31 @@ async function main() {
 
     await dynamicBench(frameworkTest);
 
-    globalThis.gc?.();
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err);
+    process.exit(1);
   }
 }
 
-main();
+async function main() {
+  logPerfResult(perfReportHeaders());
+
+  for (let i = 0, l = frameworkInfo.length; i < l; i++) {
+    await new Promise<void>((resolve, reject) =>
+      cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
+        }
+      })
+    );
+  }
+}
+
+if (cluster.isPrimary) {
+  main();
+} else {
+  testFramework(frameworkInfo[+process.env.FRAMEWORK_ID!]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ async function main() {
   logPerfResult(perfReportHeaders());
   (globalThis as any).__DEV__ = true;
 
-  for (const frameworkTest of frameworkInfo) {
+  for (const frameworkTestPromise of frameworkInfo) {
+    const frameworkTest = await frameworkTestPromise();
     const { framework } = frameworkTest;
-
     await kairoBench(framework);
     await molBench(framework);
     sbench(framework);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "target": "ESNext",
     "moduleResolution": "Bundler",
+    "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "types": ["@types/node"],
     "noEmit": true,


### PR DESCRIPTION
Hello,
I am opening this PR because I have noticed that running the benchmarks for all signal libraries in the same process gives different results than running the benchmarks for each single library separately.
To avoid any interference between signal libraries, and to improve the reliability of tests, I think it is best to run each library in its own process, so that's what I implemented in this PR.
Thank you!