### PR TITLE
Export tests suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+results.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "printWidth": 140,
   "singleQuote": false,
   "jsxSingleQuote": false,
   "semi": true,

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "vitest run",
-    "build": "esbuild src/index.ts --bundle --format=cjs --platform=node --outdir=dist --sourcemap=external",
+    "build": "esbuild src/index.ts --bundle --splitting --format=esm --platform=node --outdir=dist --sourcemap=external",
     "run": "node --expose-gc dist/index.js",
-    "bench": "esbuild src/index.ts --bundle --format=cjs --platform=node | node --expose-gc"
+    "bench": "pnpm run build && pnpm run run"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -2,18 +2,20 @@
   "name": "js-reactivity-benchmark",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "build": "esbuild src/index.ts --bundle --splitting --format=esm --platform=node --outdir=dist --sourcemap=external",
-    "run": "node --expose-gc dist/index.js",
+    "build": "esbuild src/main.ts --bundle --splitting --format=esm --platform=node --outdir=dist --sourcemap=external",
+    "prepare": "esbuild src/index.ts --bundle --splitting --format=esm --platform=node --outdir=dist --sourcemap=external && tsc -p tsconfig.d.json",
+    "run": "node --expose-gc dist/main.js",
     "bench": "pnpm run build && pnpm run run"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "@amadeus-it-group/tansu": "^2.0.0",
     "@angular/core": "19.0.6",
     "@preact/signals": "^2.0.0",
@@ -34,12 +36,11 @@
     "solid-js": "^1.9.4",
     "svelte": "5.17.3",
     "usignal": "^0.9.0",
-    "valtio": "^2.1.2"
-  },
-  "devDependencies": {
+    "valtio": "^2.1.2",
     "@types/node": "^22.10.5",
     "esbuild": "^0.24.2",
     "prettier": "^3.4.2",
+    "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@amadeus-it-group/tansu':
         specifier: ^2.0.0
         version: 2.0.0
@@ -20,6 +20,9 @@ importers:
       '@reactively/core':
         specifier: ^0.0.8
         version: 0.0.8
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.10.5
       '@vue/reactivity':
         specifier: ^3.5.13
         version: 3.5.13
@@ -29,6 +32,9 @@ importers:
       compostate:
         specifier: 0.6.0-alpha.1
         version: 0.6.0-alpha.1
+      esbuild:
+        specifier: ^0.24.2
+        version: 0.24.2
       kairo:
         specifier: 0.6.0-rc.0
         version: 0.6.0-rc.0
@@ -44,6 +50,9 @@ importers:
       preact:
         specifier: ^10.25.4
         version: 10.25.4
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
       random:
         specifier: ^5.1.1
         version: 5.1.1
@@ -65,22 +74,15 @@ importers:
       svelte:
         specifier: 5.17.3
         version: 5.17.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
       usignal:
         specifier: ^0.9.0
         version: 0.9.0
       valtio:
         specifier: ^2.1.2
         version: 2.1.2(react@19.0.0)
-    devDependencies:
-      '@types/node':
-        specifier: ^22.10.5
-        version: 22.10.5
-      esbuild:
-        specifier: ^0.24.2
-        version: 0.24.2
-      prettier:
-        specifier: ^3.4.2
-        version: 3.4.2
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@22.10.5)
@@ -1110,6 +1112,11 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -1992,6 +1999,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@4.9.5: {}
+
+  typescript@5.7.3: {}
 
   undici-types@6.20.0: {}
 

--- a/results.html
+++ b/results.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>js-reactivity-benchmark results</title>
+    <script src="./results.js"></script>
+  </head>
+  <body>
+    <style>
+      canvas {
+        margin-bottom: 30px;
+      }
+    </style>
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.js"
+      crossorigin="anonymous"
+      integrity="sha256-KBLLiCX9xXRp6y97sFXpQpJE5ZmSBRHuR36ChJm2Mss="
+    ></script>
+    <h1>js-reactivity-benchmark results</h1>
+    <script type="module">
+      const BENCHMARK_RESULTS = globalThis.BENCHMARK_RESULTS;
+      if (!BENCHMARK_RESULTS) {
+        const msg = document.createElement("div");
+        msg.textContent = 'Run benchmarks with "pnpm bench" then refresh this page to see the results.';
+        document.body.appendChild(msg);
+      } else {
+        const results = BENCHMARK_RESULTS.results;
+        const createChart = (label, data, props) => {
+          const canvas = document.createElement("canvas");
+          document.body.appendChild(canvas);
+          new Chart(canvas.getContext("2d"), {
+            type: "bar",
+            data: {
+              labels: data.map(({ label }) => label),
+              datasets: props.map((prop) => ({
+                label: prop,
+                data: data.map((item) => item[prop]),
+                borderWidth: 1,
+                backgroundColor: data.map(({ color }) => color),
+              })),
+            },
+            options: {
+              indexAxis: "y",
+              plugins: {
+                title: {
+                  display: true,
+                  text: label,
+                },
+                legend: {
+                  display: false,
+                },
+              },
+            },
+          });
+        };
+        const progressiveColors = [
+          [0, 255, 0],
+          [255, 255, 0],
+          [255, 0, 0],
+        ];
+        results.forEach((framework, i) => {
+          const percent = results.length === 1 ? 0 : i / (results.length - 1);
+          const [startColor, endColor] =
+            percent < 0.5 ? [progressiveColors[0], progressiveColors[1]] : [progressiveColors[1], progressiveColors[2]];
+          const relativePercent = percent < 0.5 ? percent * 2 : (percent - 0.5) * 2;
+          const r = Math.round(startColor[0] + (endColor[0] - startColor[0]) * relativePercent);
+          const g = Math.round(startColor[1] + (endColor[1] - startColor[1]) * relativePercent);
+          const b = Math.round(startColor[2] + (endColor[2] - startColor[2]) * relativePercent);
+          framework.color = `rgba(${r}, ${g}, ${b}, 0.9)`;
+        });
+        createChart(
+          "Average time",
+          results.map(({ framework, average, color }) => ({ label: framework, average, color })),
+          ["average"]
+        );
+        Object.keys(results[0].tests).forEach((testName) => {
+          const data = results
+            .map(({ framework, tests, color }) => {
+              const testInfo = tests[testName];
+              if (!testInfo || testInfo.length === 0) {
+                return null;
+              }
+              let min = Infinity;
+              let max = -Infinity;
+              let sum = 0;
+              for (const time of testInfo) {
+                if (time < min) {
+                  min = time;
+                }
+                if (time > max) {
+                  max = time;
+                }
+                sum += time;
+              }
+              const average = sum / testInfo.length;
+              return {
+                label: framework,
+                min,
+                average,
+                max,
+                color,
+              };
+            })
+            .filter((result) => !!result)
+            .sort(({ average: average1 }, { average: average2 }) => average1 - average2);
+          createChart(testName, data, ["min", "average", "max"]);
+        });
+        const addInfo = (text, tag = "div") => {
+          const infos = document.createElement(tag);
+          infos.innerText = text;
+          document.body.appendChild(infos);
+        };
+        addInfo(`Tests start time: ${new Date(BENCHMARK_RESULTS.startTime).toString()}`);
+        addInfo(`Tests end time: ${new Date(BENCHMARK_RESULTS.endTime).toString()}`);
+        addInfo(`${JSON.stringify(BENCHMARK_RESULTS.system, null, 2)}`, "pre");
+      }
+    </script>
+  </body>
+</html>

--- a/src/cellxBench.ts
+++ b/src/cellxBench.ts
@@ -1,5 +1,4 @@
 // The following is an implementation of the cellx benchmark https://github.com/Riim/cellx/blob/master/perf/perf.html
-import { logPerfResult } from "./util/perfLogging";
 import { Computed, ReactiveFramework } from "./util/reactiveFramework";
 
 const cellx = (framework: ReactiveFramework, layers: number) => {
@@ -117,10 +116,10 @@ export const cellxbench = (framework: ReactiveFramework) => {
       total += elapsed;
     }
 
-    logPerfResult({
+    process.send?.({
       framework: framework.name,
       test: `cellx${layers}`,
-      time: total.toFixed(2),
+      time: total,
     });
   }
 

--- a/src/cellxBench.ts
+++ b/src/cellxBench.ts
@@ -1,5 +1,6 @@
 // The following is an implementation of the cellx benchmark https://github.com/Riim/cellx/blob/master/perf/perf.html
 import { Computed, ReactiveFramework } from "./util/reactiveFramework";
+import { PerfResultCallback } from "./util/perfResult";
 
 const cellx = (framework: ReactiveFramework, layers: number) => {
   return framework.withBuild(() => {
@@ -86,7 +87,7 @@ type BenchmarkResults = [
   readonly [number, number, number, number],
 ];
 
-export const cellxbench = (framework: ReactiveFramework) => {
+export const cellxbench = (framework: ReactiveFramework, resultCallback: PerfResultCallback) => {
   globalThis.gc?.();
 
   const expected: Record<number, BenchmarkResults> = {
@@ -116,7 +117,7 @@ export const cellxbench = (framework: ReactiveFramework) => {
       total += elapsed;
     }
 
-    process.send?.({
+    resultCallback({
       framework: framework.name,
       test: `cellx${layers}`,
       time: total,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,48 +1,30 @@
 import { TestConfig, FrameworkInfo } from "./util/frameworkTypes";
 
-import { alienFramework } from "./frameworks/alienSignals";
-import { angularFramework } from "./frameworks/angularSignals";
-import { mobxFramework } from "./frameworks/mobx";
-import { tc39SignalsProposalStage0 } from "./frameworks/tc39-proposal-signals-stage-0";
-import { molWireFramework } from "./frameworks/molWire";
-import { obyFramework } from "./frameworks/oby";
-import { preactSignalFramework } from "./frameworks/preactSignals";
-import { reactivelyFramework } from "./frameworks/reactively";
-import { signiaFramework } from "./frameworks/signia";
-import { solidFramework } from "./frameworks/solid";
-import { sFramework } from "./frameworks/s";
-import { usignalFramework } from "./frameworks/uSignal";
-import { vueReactivityFramework } from "./frameworks/vueReactivity";
-import { svelteFramework } from "./frameworks/svelte";
-import { tansuFramework } from "./frameworks/tansu";
-// import { compostateFramework } from "./frameworks/compostate";
-// import { valtioFramework } from "./frameworks/valtio";
-
-export const frameworkInfo: FrameworkInfo[] = [
-  { framework: alienFramework, testPullCounts: true },
-  { framework: preactSignalFramework, testPullCounts: true },
-  { framework: svelteFramework, testPullCounts: true },
-  { framework: tc39SignalsProposalStage0, testPullCounts: true },
-  { framework: reactivelyFramework, testPullCounts: true },
-  { framework: sFramework },
-  { framework: tansuFramework, testPullCounts: true },
-  { framework: angularFramework, testPullCounts: true },
-  { framework: molWireFramework, testPullCounts: true },
-  { framework: obyFramework, testPullCounts: true },
-  { framework: signiaFramework, testPullCounts: true },
-  { framework: solidFramework },
-  { framework: usignalFramework, testPullCounts: true },
-  { framework: vueReactivityFramework, testPullCounts: true },
+export const frameworkInfo: (() => Promise<FrameworkInfo>)[] = [
+  async () => ({ framework: (await import("./frameworks/alienSignals")).alienFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/preactSignals")).preactSignalFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/svelte")).svelteFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/tc39-proposal-signals-stage-0")).tc39SignalsProposalStage0, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/reactively")).reactivelyFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/s")).sFramework }),
+  async () => ({ framework: (await import("./frameworks/tansu")).tansuFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/angularSignals")).angularFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/molWire")).molWireFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/oby")).obyFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/signia")).signiaFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/solid")).solidFramework }),
+  async () => ({ framework: (await import("./frameworks/uSignal")).usignalFramework, testPullCounts: true }),
+  async () => ({ framework: (await import("./frameworks/vueReactivity")).vueReactivityFramework, testPullCounts: true }),
   // NOTE: MobX currently hangs on some of the `dynamic` tests and `cellx` tests, so disable it if you want to run them. (https://github.com/mobxjs/mobx/issues/3926)
-  { framework: mobxFramework, testPullCounts: false },
+  async () => ({ framework: (await import("./frameworks/mobx")).mobxFramework, testPullCounts: false }),
 
   // --- Disabled frameworks ---
   // NOTE: the compostate adapter is currently broken and unused.
-  // { framework: compostateFramework },
+  // async () => ({ framework: (await import("./frameworks/compostate")).compostateFramework }),
   // NOTE: the kairo adapter is currently broken and unused.
-  // { framework: kairoFramework, testPullCounts: true },
+  // async () => ({ framework: (await import("./frameworks/kairo")).kairoFramework, testPullCounts: true }),
   // NOTE: Valtio currently hangs on some of the `dynamic` tests, so disable it if you want to run them. (https://github.com/pmndrs/valtio/discussions/949)
-  // { framework: valtioFramework },
+  // async () => ({ framework: (await import("./frameworks/valtio")).valtioFramework }),
 ];
 
 export const perfTests: TestConfig[] = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 import { TestConfig, FrameworkInfo } from "./util/frameworkTypes";
 
+export let executions = 3;
+
 export const frameworkInfo: (() => Promise<FrameworkInfo>)[] = [
   async () => ({ framework: (await import("./frameworks/alienSignals")).alienFramework, testPullCounts: true }),
   async () => ({ framework: (await import("./frameworks/preactSignals")).preactSignalFramework, testPullCounts: true }),

--- a/src/configFrameworks.ts
+++ b/src/configFrameworks.ts
@@ -1,4 +1,4 @@
-import { TestConfig, FrameworkInfo } from "./util/frameworkTypes";
+import { FrameworkInfo } from "./util/frameworkTypes";
 
 export let executions = 3;
 
@@ -27,87 +27,4 @@ export const frameworkInfo: (() => Promise<FrameworkInfo>)[] = [
   // async () => ({ framework: (await import("./frameworks/kairo")).kairoFramework, testPullCounts: true }),
   // NOTE: Valtio currently hangs on some of the `dynamic` tests, so disable it if you want to run them. (https://github.com/pmndrs/valtio/discussions/949)
   // async () => ({ framework: (await import("./frameworks/valtio")).valtioFramework }),
-];
-
-export const perfTests: TestConfig[] = [
-  {
-    name: "simple component",
-    width: 10, // can't change for decorator tests
-    staticFraction: 1, // can't change for decorator tests
-    nSources: 2, // can't change for decorator tests
-    totalLayers: 5,
-    readFraction: 0.2,
-    iterations: 600000,
-    expected: {
-      sum: 19199832,
-      count: 2640004,
-    },
-  },
-  {
-    name: "dynamic component",
-    width: 10,
-    totalLayers: 10,
-    staticFraction: 3 / 4,
-    nSources: 6,
-    readFraction: 0.2,
-    iterations: 15000,
-    expected: {
-      sum: 302310477864,
-      count: 1125003,
-    },
-  },
-  {
-    name: "large web app",
-    width: 1000,
-    totalLayers: 12,
-    staticFraction: 0.95,
-    nSources: 4,
-    readFraction: 1,
-    iterations: 7000,
-    expected: {
-      sum: 29355933696000,
-      count: 1473791,
-    },
-  },
-  {
-    name: "wide dense",
-    width: 1000,
-    totalLayers: 5,
-    staticFraction: 1,
-    nSources: 25,
-    readFraction: 1,
-    iterations: 3000,
-    expected: {
-      sum: 1171484375000,
-      count: 735756,
-    },
-  },
-  {
-    name: "deep",
-    width: 5,
-    totalLayers: 500,
-    staticFraction: 1,
-    nSources: 3,
-    readFraction: 1,
-    iterations: 500,
-    expected: {
-      sum: 3.0239642676898464e241,
-      count: 1246502,
-    },
-  },
-  // Several frameworks hang on this test, so disabling it for now.
-  // @see https://github.com/vuejs/core/issues/11928
-  // {
-  //   name: "very dynamic",
-  //   width: 100,
-  //   totalLayers: 15,
-  //   staticFraction: 0.5,
-  //   nSources: 6,
-  //   readFraction: 1,
-  //   iterations: 2000,
-  //   expected: {
-  //     sum: 15664996402790400,
-  //     count: 1078671,
-  //   },
-  // },
 ];

--- a/src/configPerfTests.ts
+++ b/src/configPerfTests.ts
@@ -1,0 +1,85 @@
+import { TestConfig } from "./util/frameworkTypes";
+
+export const perfTests: TestConfig[] = [
+    {
+      name: "simple component",
+      width: 10, // can't change for decorator tests
+      staticFraction: 1, // can't change for decorator tests
+      nSources: 2, // can't change for decorator tests
+      totalLayers: 5,
+      readFraction: 0.2,
+      iterations: 600000,
+      expected: {
+        sum: 19199832,
+        count: 2640004,
+      },
+    },
+    {
+      name: "dynamic component",
+      width: 10,
+      totalLayers: 10,
+      staticFraction: 3 / 4,
+      nSources: 6,
+      readFraction: 0.2,
+      iterations: 15000,
+      expected: {
+        sum: 302310477864,
+        count: 1125003,
+      },
+    },
+    {
+      name: "large web app",
+      width: 1000,
+      totalLayers: 12,
+      staticFraction: 0.95,
+      nSources: 4,
+      readFraction: 1,
+      iterations: 7000,
+      expected: {
+        sum: 29355933696000,
+        count: 1473791,
+      },
+    },
+    {
+      name: "wide dense",
+      width: 1000,
+      totalLayers: 5,
+      staticFraction: 1,
+      nSources: 25,
+      readFraction: 1,
+      iterations: 3000,
+      expected: {
+        sum: 1171484375000,
+        count: 735756,
+      },
+    },
+    {
+      name: "deep",
+      width: 5,
+      totalLayers: 500,
+      staticFraction: 1,
+      nSources: 3,
+      readFraction: 1,
+      iterations: 500,
+      expected: {
+        sum: 3.0239642676898464e241,
+        count: 1246502,
+      },
+    },
+    // Several frameworks hang on this test, so disabling it for now.
+    // @see https://github.com/vuejs/core/issues/11928
+    // {
+    //   name: "very dynamic",
+    //   width: 100,
+    //   totalLayers: 15,
+    //   staticFraction: 0.5,
+    //   nSources: 6,
+    //   readFraction: 1,
+    //   iterations: 2000,
+    //   expected: {
+    //     sum: 15664996402790400,
+    //     count: 1078671,
+    //   },
+    // },
+  ];
+  

--- a/src/dynamicBench.ts
+++ b/src/dynamicBench.ts
@@ -1,5 +1,5 @@
 import { Counter, makeGraph, runGraph } from "./util/dependencyGraph";
-import { logPerfResult, perfRowStrings } from "./util/perfLogging";
+import { makeTitle } from "./util/perfLogging";
 import { verifyBenchResult } from "./util/perfTests";
 import { FrameworkInfo } from "./util/frameworkTypes";
 import { perfTests } from "./config";
@@ -41,7 +41,7 @@ export async function dynamicBench(
       return { sum, count: counter.count };
     });
 
-    logPerfResult(perfRowStrings(framework.name, config, timedResult));
+    process.send?.({ framework: framework.name, test: `${makeTitle(config)} (${config.name || ""})`, time: timedResult.timing.time });
     verifyBenchResult(frameworkTest, config, timedResult);
   }
 }

--- a/src/dynamicBench.ts
+++ b/src/dynamicBench.ts
@@ -2,14 +2,16 @@ import { Counter, makeGraph, runGraph } from "./util/dependencyGraph";
 import { makeTitle } from "./util/perfLogging";
 import { verifyBenchResult } from "./util/perfTests";
 import { FrameworkInfo } from "./util/frameworkTypes";
-import { perfTests } from "./config";
+import { perfTests } from "./configPerfTests";
 import { fastestTest } from "./util/benchRepeat";
+import { PerfResultCallback } from "./util/perfResult";
 
 /** benchmark a single test under single framework.
  * The test is run multiple times and the fastest result is logged to the console.
  */
 export async function dynamicBench(
   frameworkTest: FrameworkInfo,
+  resultCallback: PerfResultCallback,
   testRepeats = 1
 ): Promise<void> {
   const { framework } = frameworkTest;
@@ -41,7 +43,7 @@ export async function dynamicBench(
       return { sum, count: counter.count };
     });
 
-    process.send?.({ framework: framework.name, test: `${makeTitle(config)} (${config.name || ""})`, time: timedResult.timing.time });
+    resultCallback({ framework: framework.name, test: `${makeTitle(config)} (${config.name || ""})`, time: timedResult.timing.time });
     verifyBenchResult(frameworkTest, config, timedResult);
   }
 }

--- a/src/frameworks.test.ts
+++ b/src/frameworks.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from "vitest";
 import { FrameworkInfo, TestConfig } from "./util/frameworkTypes";
 import { frameworkInfo } from "./config";
 
-frameworkInfo.forEach((frameworkInfo) => frameworkTests(frameworkInfo));
+(await Promise.all(frameworkInfo.map((frameworkLoader) => frameworkLoader()))).forEach((frameworkInfo) => frameworkTests(frameworkInfo));
 
 function makeConfig(): TestConfig {
   return {

--- a/src/frameworks.test.ts
+++ b/src/frameworks.test.ts
@@ -1,7 +1,7 @@
 import { Counter, makeGraph, runGraph } from "./util/dependencyGraph";
 import { expect, test, vi } from "vitest";
 import { FrameworkInfo, TestConfig } from "./util/frameworkTypes";
-import { frameworkInfo } from "./config";
+import { frameworkInfo } from "./configFrameworks";
 
 (await Promise.all(frameworkInfo.map((frameworkLoader) => frameworkLoader()))).forEach((frameworkInfo) => frameworkTests(frameworkInfo));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import cluster from "cluster";
 import { dynamicBench } from "./dynamicBench";
 // import { cellxbench } from "./cellxBench";
 import { sbench } from "./sBench";
-import { frameworkInfo } from "./config";
+import { frameworkInfo, executions } from "./config";
 import { logPerfResult, perfReportHeaders } from "./util/perfLogging";
 import { molBench } from "./molBench";
 import { kairoBench } from "./kairoBench";
@@ -32,19 +32,70 @@ async function testFramework(frameworkTestPromise: () => Promise<FrameworkInfo>)
   }
 }
 
+const average = (times: number[]) => times.reduce((a, b) => a + b, 0) / times.length;
+
 async function main() {
   logPerfResult(perfReportHeaders());
 
-  for (let i = 0, l = frameworkInfo.length; i < l; i++) {
-    await new Promise<void>((resolve, reject) =>
-      cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
-        }
+  const frameworkSummary = new Map<string, Record<string, number[]>>();
+  cluster.on("message", (_, message) => {
+    logPerfResult({
+      framework: message.framework,
+      test: message.test,
+      time: message.time.toFixed(2),
+    });
+    let framework = frameworkSummary.get(message.framework);
+    if (!framework) {
+      framework = {};
+      frameworkSummary.set(message.framework, framework);
+    }
+    let test = framework[message.test];
+    if (!test) {
+      test = [];
+      framework[message.test] = test;
+    }
+    test.push(message.time);
+  });
+
+  const logSummary = () => {
+    const summary = [...frameworkSummary.entries()]
+      .map(([framework, tests]) => {
+        const averages = Object.values(tests).map(average);
+        return { framework, testsCount: averages.length, average: average(averages), tests };
       })
-    );
+      .sort(({ average: average1 }, { average: average2 }) => average1 - average2);
+    if (summary.length === 0) {
+      return;
+    }
+    console.log("");
+    logPerfResult(perfReportHeaders());
+    for (const { framework, average, testsCount } of summary) {
+      logPerfResult({
+        framework,
+        test: `Average (${testsCount} tests)`,
+        time: average.toFixed(2),
+      });
+    }
+    console.log("");
+  };
+  process.on("SIGUSR1", logSummary);
+  process.on("SIGINT", () => process.exit(1));
+  process.on("SIGTERM", () => process.exit(1));
+  process.on("exit", logSummary);
+
+  for (let n = 0; n < executions; n++) {
+    for (let i = 0, l = frameworkInfo.length; i < l; i++) {
+      await new Promise<void>((resolve, reject) =>
+        cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
+          }
+        })
+      );
+    }
+    logSummary();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import cluster from "cluster";
 import { dynamicBench } from "./dynamicBench";
 // import { cellxbench } from "./cellxBench";
 import { sbench } from "./sBench";
@@ -5,12 +6,12 @@ import { frameworkInfo } from "./config";
 import { logPerfResult, perfReportHeaders } from "./util/perfLogging";
 import { molBench } from "./molBench";
 import { kairoBench } from "./kairoBench";
+import { FrameworkInfo } from "./util/frameworkTypes";
 
-async function main() {
-  logPerfResult(perfReportHeaders());
-  (globalThis as any).__DEV__ = true;
+async function testFramework(frameworkTestPromise: () => Promise<FrameworkInfo>) {
+  try {
+    (globalThis as any).__DEV__ = true;
 
-  for (const frameworkTestPromise of frameworkInfo) {
     const frameworkTest = await frameworkTestPromise();
     const { framework } = frameworkTest;
     await kairoBench(framework);
@@ -24,8 +25,31 @@ async function main() {
 
     await dynamicBench(frameworkTest);
 
-    globalThis.gc?.();
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err);
+    process.exit(1);
   }
 }
 
-main();
+async function main() {
+  logPerfResult(perfReportHeaders());
+
+  for (let i = 0, l = frameworkInfo.length; i < l; i++) {
+    await new Promise<void>((resolve, reject) =>
+      cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
+        }
+      })
+    );
+  }
+}
+
+if (cluster.isPrimary) {
+  main();
+} else {
+  testFramework(frameworkInfo[+process.env.FRAMEWORK_ID!]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ async function main() {
   logPerfResult(perfReportHeaders());
   (globalThis as any).__DEV__ = true;
 
-  for (const frameworkTest of frameworkInfo) {
+  for (const frameworkTestPromise of frameworkInfo) {
+    const frameworkTest = await frameworkTestPromise();
     const { framework } = frameworkTest;
-
     await kairoBench(framework);
     await molBench(framework);
     sbench(framework);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,136 +1,27 @@
-import cluster from "cluster";
-import os from "os";
 import { dynamicBench } from "./dynamicBench";
 // import { cellxbench } from "./cellxBench";
 import { sbench } from "./sBench";
-import { frameworkInfo, executions } from "./config";
-import { logPerfResult, perfReportHeaders } from "./util/perfLogging";
 import { molBench } from "./molBench";
 import { kairoBench } from "./kairoBench";
 import { FrameworkInfo } from "./util/frameworkTypes";
-import { writeFileSync } from "fs";
+import { PerfResultCallback } from "./util/perfResult";
 
-async function testFramework(frameworkTestPromise: () => Promise<FrameworkInfo>) {
-  try {
-    (globalThis as any).__DEV__ = true;
+export { logPerfResult, logPerfHeaders } from "./util/perfLogging";
+export { FrameworkInfo };
+export { Computed, ReactiveFramework, Signal } from "./util/reactiveFramework";
 
-    const frameworkTest = await frameworkTestPromise();
-    const { framework } = frameworkTest;
-    await kairoBench(framework);
-    await molBench(framework);
-    sbench(framework);
+export async function testFramework(frameworkTest: FrameworkInfo, resultCallback: PerfResultCallback) {
+  (globalThis as any).__DEV__ = true;
 
-    // MobX, Valtio, and Svelte fail this test currently, so disabling it for now.
-    // @see https://github.com/mobxjs/mobx/issues/3926
-    // @see https://github.com/sveltejs/svelte/discussions/13277
-    // cellxbench(framework);
+  const { framework } = frameworkTest;
+  await kairoBench(framework, resultCallback);
+  await molBench(framework, resultCallback);
+  sbench(framework, resultCallback);
 
-    await dynamicBench(frameworkTest);
+  // MobX, Valtio, and Svelte fail this test currently, so disabling it for now.
+  // @see https://github.com/mobxjs/mobx/issues/3926
+  // @see https://github.com/sveltejs/svelte/discussions/13277
+  // cellxbench(framework, resultCallback);
 
-    process.exit(0);
-  } catch (err: any) {
-    console.error(err);
-    process.exit(1);
-  }
-}
-
-const average = (times: number[]) => times.reduce((a, b) => a + b, 0) / times.length;
-
-async function main() {
-  const system = {
-    engine: process.versions,
-    os: {
-      platform: os.platform(),
-      type: os.type(),
-      release: os.release(),
-      version: os.version(),
-    },
-    hardware: {
-      machine: os.machine(),
-      cpus: os.cpus().map(({ model }) => model),
-    },
-  };
-  const startTime = Date.now();
-  logPerfResult(perfReportHeaders());
-
-  const frameworkSummary = new Map<string, Record<string, number[]>>();
-  cluster.on("message", (_, message) => {
-    logPerfResult({
-      framework: message.framework,
-      test: message.test,
-      time: message.time.toFixed(2),
-    });
-    let framework = frameworkSummary.get(message.framework);
-    if (!framework) {
-      framework = {};
-      frameworkSummary.set(message.framework, framework);
-    }
-    let test = framework[message.test];
-    if (!test) {
-      test = [];
-      framework[message.test] = test;
-    }
-    test.push(message.time);
-  });
-
-  const logSummary = () => {
-    const summary = [...frameworkSummary.entries()]
-      .map(([framework, tests]) => {
-        const averages = Object.values(tests).map(average);
-        return { framework, testsCount: averages.length, average: average(averages), tests };
-      })
-      .sort(({ average: average1 }, { average: average2 }) => average1 - average2);
-    if (summary.length === 0) {
-      return;
-    }
-    console.log("");
-    logPerfResult(perfReportHeaders());
-    for (const { framework, average, testsCount } of summary) {
-      logPerfResult({
-        framework,
-        test: `Average (${testsCount} tests)`,
-        time: average.toFixed(2),
-      });
-    }
-    console.log("");
-    const endTime = Date.now();
-    writeFileSync(
-      "results.js",
-      `globalThis.BENCHMARK_RESULTS = ${JSON.stringify(
-        {
-          startTime,
-          endTime,
-          system,
-          results: summary,
-        },
-        null,
-        "\t"
-      )};`
-    );
-  };
-  process.on("SIGUSR1", logSummary);
-  process.on("SIGINT", () => process.exit(1));
-  process.on("SIGTERM", () => process.exit(1));
-  process.on("exit", logSummary);
-
-  for (let n = 0; n < executions; n++) {
-    for (let i = 0, l = frameworkInfo.length; i < l; i++) {
-      await new Promise<void>((resolve, reject) =>
-        cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
-          if (code === 0) {
-            resolve();
-          } else {
-            reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
-          }
-        })
-      );
-    }
-    logSummary();
-  }
-}
-
-if (cluster.isPrimary) {
-  main();
-} else {
-  testFramework(frameworkInfo[+process.env.FRAMEWORK_ID!]);
+  await dynamicBench(frameworkTest, resultCallback);
 }

--- a/src/kairoBench.ts
+++ b/src/kairoBench.ts
@@ -7,7 +7,6 @@ import { repeatedObservers } from "./kairo/repeated";
 import { triangle } from "./kairo/triangle";
 import { unstable } from "./kairo/unstable";
 import { fastestTest } from "./util/benchRepeat";
-import { logPerfResult } from "./util/perfLogging";
 import { ReactiveFramework } from "./util/reactiveFramework";
 
 const cases = [
@@ -37,10 +36,10 @@ export async function kairoBench(framework: ReactiveFramework) {
       }
     });
 
-    logPerfResult({
+    process.send?.({
       framework: framework.name,
       test: c.name,
-      time: timing.time.toFixed(2),
+      time: timing.time,
     });
   }
 }

--- a/src/kairoBench.ts
+++ b/src/kairoBench.ts
@@ -8,6 +8,7 @@ import { triangle } from "./kairo/triangle";
 import { unstable } from "./kairo/unstable";
 import { fastestTest } from "./util/benchRepeat";
 import { ReactiveFramework } from "./util/reactiveFramework";
+import { PerfResultCallback } from "./util/perfResult";
 
 const cases = [
   avoidablePropagation,
@@ -20,7 +21,7 @@ const cases = [
   unstable,
 ];
 
-export async function kairoBench(framework: ReactiveFramework) {
+export async function kairoBench(framework: ReactiveFramework, resultCallback: PerfResultCallback) {
   for (const c of cases) {
     const iter = framework.withBuild(() => {
       const iter = c(framework);
@@ -36,7 +37,7 @@ export async function kairoBench(framework: ReactiveFramework) {
       }
     });
 
-    process.send?.({
+    resultCallback({
       framework: framework.name,
       test: c.name,
       time: timing.time,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,116 @@
+import cluster from "cluster";
+import os from "os";
+import { frameworkInfo, executions } from "./configFrameworks";
+import { logPerfResult, logPerfHeaders } from "./util/perfLogging";
+import { writeFileSync } from "fs";
+import { testFramework } from "./index";
+
+const average = (times: number[]) => times.reduce((a, b) => a + b, 0) / times.length;
+
+async function main() {
+  const system = {
+    engine: process.versions,
+    os: {
+      platform: os.platform(),
+      type: os.type(),
+      release: os.release(),
+      version: os.version(),
+    },
+    hardware: {
+      machine: os.machine(),
+      cpus: os.cpus().map(({ model }) => model),
+    },
+  };
+  const startTime = Date.now();
+  logPerfHeaders();
+
+  const frameworkSummary = new Map<string, Record<string, number[]>>();
+  cluster.on("message", (_, message) => {
+    logPerfResult({
+      framework: message.framework,
+      test: message.test,
+      time: message.time,
+    });
+    let framework = frameworkSummary.get(message.framework);
+    if (!framework) {
+      framework = {};
+      frameworkSummary.set(message.framework, framework);
+    }
+    let test = framework[message.test];
+    if (!test) {
+      test = [];
+      framework[message.test] = test;
+    }
+    test.push(message.time);
+  });
+
+  const logSummary = () => {
+    const summary = [...frameworkSummary.entries()]
+      .map(([framework, tests]) => {
+        const averages = Object.values(tests).map(average);
+        return { framework, testsCount: averages.length, average: average(averages), tests };
+      })
+      .sort(({ average: average1 }, { average: average2 }) => average1 - average2);
+    if (summary.length === 0) {
+      return;
+    }
+    console.log("");
+    logPerfHeaders();
+    for (const { framework, average, testsCount } of summary) {
+      logPerfResult({
+        framework,
+        test: `Average (${testsCount} tests)`,
+        time: average,
+      });
+    }
+    console.log("");
+    const endTime = Date.now();
+    writeFileSync(
+      "results.js",
+      `globalThis.BENCHMARK_RESULTS = ${JSON.stringify(
+        {
+          startTime,
+          endTime,
+          system,
+          results: summary,
+        },
+        null,
+        "\t"
+      )};`
+    );
+  };
+  process.on("SIGUSR1", logSummary);
+  process.on("SIGINT", () => process.exit(1));
+  process.on("SIGTERM", () => process.exit(1));
+  process.on("exit", logSummary);
+
+  for (let n = 0; n < executions; n++) {
+    for (let i = 0, l = frameworkInfo.length; i < l; i++) {
+      await new Promise<void>((resolve, reject) =>
+        cluster.fork({ FRAMEWORK_ID: i }).addListener("exit", (code, signal) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Framework test failed with code ${code} and signal ${signal}`));
+          }
+        })
+      );
+    }
+    logSummary();
+  }
+}
+
+if (cluster.isPrimary) {
+  main();
+} else {
+  (async () => {
+    try {
+      const framework = await frameworkInfo[+process.env.FRAMEWORK_ID!]();
+      await testFramework(framework, process.send!.bind(process));
+      process.exit(0);
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+  })();
+}

--- a/src/molBench.ts
+++ b/src/molBench.ts
@@ -1,5 +1,4 @@
 import { fastestTest } from "./util/benchRepeat";
-import { logPerfResult } from "./util/perfLogging";
 import { ReactiveFramework } from "./util/reactiveFramework";
 
 function fib(n: number): number {
@@ -55,9 +54,9 @@ export async function molBench(framework: ReactiveFramework) {
     }
   });
 
-  logPerfResult({
+  process.send?.({
     framework: framework.name,
     test: "molBench",
-    time: timing.time.toFixed(2),
+    time: timing.time,
   });
 }

--- a/src/molBench.ts
+++ b/src/molBench.ts
@@ -1,5 +1,6 @@
 import { fastestTest } from "./util/benchRepeat";
 import { ReactiveFramework } from "./util/reactiveFramework";
+import { PerfResultCallback } from "./util/perfResult";
 
 function fib(n: number): number {
   if (n < 2) return 1;
@@ -12,7 +13,7 @@ function hard(n: number, _log: string) {
 
 const numbers = Array.from({ length: 5 }, (_, i) => i);
 
-export async function molBench(framework: ReactiveFramework) {
+export async function molBench(framework: ReactiveFramework, resultCallback: PerfResultCallback) {
   let res = [];
   const iter = framework.withBuild(() => {
     const A = framework.signal(0);
@@ -54,7 +55,7 @@ export async function molBench(framework: ReactiveFramework) {
     }
   });
 
-  process.send?.({
+  resultCallback({
     framework: framework.name,
     test: "molBench",
     time: timing.time,

--- a/src/sBench.ts
+++ b/src/sBench.ts
@@ -1,5 +1,4 @@
 // Inspired by https://github.com/solidjs/solid/blob/main/packages/solid/bench/bench.cjs
-import { logPerfResult } from "./util/perfLogging";
 import { Computed, Signal, ReactiveFramework } from "./util/reactiveFramework";
 
 const COUNT = 1e5;
@@ -31,10 +30,10 @@ export function sbench(framework: ReactiveFramework) {
     scount: number
   ) {
     const time = run(fn, count, scount);
-    logPerfResult({
+    process.send?.({
       framework: framework.name,
       test: fn.name,
-      time: time.toFixed(2),
+      time: time,
     });
   }
 

--- a/src/sBench.ts
+++ b/src/sBench.ts
@@ -1,10 +1,11 @@
 // Inspired by https://github.com/solidjs/solid/blob/main/packages/solid/bench/bench.cjs
 import { Computed, Signal, ReactiveFramework } from "./util/reactiveFramework";
+import { PerfResultCallback } from "./util/perfResult";
 
 const COUNT = 1e5;
 
 type Reader = () => number;
-export function sbench(framework: ReactiveFramework) {
+export function sbench(framework: ReactiveFramework, resultCallback: PerfResultCallback) {
   bench(createDataSignals, COUNT, COUNT);
   bench(createComputations0to1, COUNT, 0);
   bench(createComputations1to1, COUNT, COUNT);
@@ -30,7 +31,7 @@ export function sbench(framework: ReactiveFramework) {
     scount: number
   ) {
     const time = run(fn, count, scount);
-    process.send?.({
+    resultCallback({
       framework: framework.name,
       test: fn.name,
       time: time,

--- a/src/util/perfLogging.ts
+++ b/src/util/perfLogging.ts
@@ -1,5 +1,4 @@
 import { TestConfig } from "./frameworkTypes";
-import { TestResult, TimingResult } from "./perfTests";
 
 export function logPerfResult(row: PerfRowStrings): void {
   const line = Object.values(trimColumns(row)).join(" , ");
@@ -13,7 +12,7 @@ export interface PerfRowStrings {
 }
 
 const columnWidth = {
-  framework: 22,
+  framework: 32,
   test: 60,
   time: 8,
 };
@@ -23,20 +22,6 @@ export function perfReportHeaders(): PerfRowStrings {
   const kv = keys.map((key) => [key, key]);
   const untrimmed = Object.fromEntries(kv);
   return trimColumns(untrimmed);
-}
-
-export function perfRowStrings(
-  frameworkName: string,
-  config: TestConfig,
-  timed: TimingResult<TestResult>
-): PerfRowStrings {
-  const { timing } = timed;
-
-  return {
-    framework: frameworkName,
-    test: `${makeTitle(config)} (${config.name || ""})`,
-    time: timing.time.toFixed(2),
-  };
 }
 
 export function makeTitle(config: TestConfig): string {

--- a/src/util/perfLogging.ts
+++ b/src/util/perfLogging.ts
@@ -1,6 +1,19 @@
 import { TestConfig } from "./frameworkTypes";
+import { PerfResult } from "./perfResult";
 
-export function logPerfResult(row: PerfRowStrings): void {
+export function logPerfHeaders(): void {
+  logPerfRow(perfReportHeaders());
+}
+
+export function logPerfResult(row: PerfResult): void {
+  logPerfRow({
+    framework: row.framework,
+    test: row.test,
+    time: row.time.toFixed(2),
+  });
+}
+
+function logPerfRow(row: PerfRowStrings): void {
   const line = Object.values(trimColumns(row)).join(" , ");
   console.log(line);
 }

--- a/src/util/perfResult.ts
+++ b/src/util/perfResult.ts
@@ -1,0 +1,7 @@
+export interface PerfResult {
+  framework: string;
+  test: string;
+  time: number;
+}
+
+export type PerfResultCallback = (result: PerfResult) => void;

--- a/tsconfig.d.json
+++ b/tsconfig.d.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
+  "files": ["src/index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "target": "ESNext",
     "moduleResolution": "Bundler",
+    "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "types": ["@types/node"],
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "strict": true,
     "target": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
This PR is based on #13 and #14
It exports the tests suite so that it is possible to easily use it from any repository. For an example, cf [my PR on signal-polyfill](https://github.com/proposal-signals/signal-polyfill/pull/47)
Ideally, the `js-reactivity-benchmark` package should be published to npm.
